### PR TITLE
ArgumentOutOfRangeException fix --Cleanup

### DIFF
--- a/CsprojCleaner.App.WindowsForms/Form1.cs
+++ b/CsprojCleaner.App.WindowsForms/Form1.cs
@@ -18,9 +18,6 @@ namespace CsprojCleaner.App.WindowsForms
         {
             InitializeComponent();
             FormBorderStyle = FormBorderStyle.FixedSingle;
-
-            _countItems = 0;
-            _countLoop = 0;
         }
 
         private void Label1Click(object sender, EventArgs e)
@@ -103,6 +100,8 @@ namespace CsprojCleaner.App.WindowsForms
 
             lock (stateLock)
             {
+                _countItems = 0;
+                _countLoop = 0;
                 currentCount = 0;
                 CleanButton.Enabled = false;
             }


### PR DESCRIPTION
Fixing crash do programa quando tentava dar clean mais de uma vez
devido a progress bar value não aceitar valores maiores que 150 e a variável _count.. não era reiniciada.
Apenas movi a inicialização dessas variáveis contadoras para o método ThreadClean.
